### PR TITLE
last value of ConfigEntries for topic is used for all entries, single variable in for loop

### DIFF
--- a/admin/kafka_admin.go
+++ b/admin/kafka_admin.go
@@ -10,7 +10,6 @@ package admin
 
 import (
 	"fmt"
-
 	"github.com/Shopify/sarama"
 	"github.com/tryfix/errors"
 	"github.com/tryfix/log"

--- a/admin/kafka_admin.go
+++ b/admin/kafka_admin.go
@@ -10,6 +10,7 @@ package admin
 
 import (
 	"fmt"
+
 	"github.com/Shopify/sarama"
 	"github.com/tryfix/errors"
 	"github.com/tryfix/log"
@@ -139,7 +140,8 @@ func (c *kafkaAdmin) CreateTopics(topics map[string]*Topic) error {
 		}
 		details.ConfigEntries = map[string]*string{}
 		for cName, config := range info.ConfigEntries {
-			details.ConfigEntries[cName] = &config
+			configCpy := config
+			details.ConfigEntries[cName] = &configCpy
 		}
 
 		err := c.admin.CreateTopic(name, details, false)


### PR DESCRIPTION
for loop has _config_ variable declared once but it is used more than once by reference. this causes the last value of all _configEntries_ to be used for all of the _configEntries_ 